### PR TITLE
Add inverted MQTT Actor for ESPEasy

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -53,6 +53,15 @@ class ESPEasyMQTT(ActorBase):
 
     def off(self):
         self.api.cache["mqtt"].client.publish(self.topic, payload=0, qos=2, retain=True)
+        
+@cbpi.actor
+class ESPEasyMQTT_Inverted(ActorBase):
+    topic = Property.Text("Topic", configurable=True, default_value="", description="MQTT TOPIC")
+    def on(self, power=100):
+        self.api.cache["mqtt"].client.publish(self.topic, payload=0, qos=2, retain=True)
+
+    def off(self):
+        self.api.cache["mqtt"].client.publish(self.topic, payload=1, qos=2, retain=True)
 
 @cbpi.sensor
 class MQTT_SENSOR(SensorActive):


### PR DESCRIPTION
Some Actors are inverted, where MQTT "0" is on, and "1" is off. Added Actor type to reflect this.